### PR TITLE
Fix relative links to the spec docs

### DIFF
--- a/best-practices-asset-and-link.md
+++ b/best-practices-asset-and-link.md
@@ -9,14 +9,14 @@
 
 ## Common Use Cases of Additional Fields for Assets
 
-As [described in the Item spec](commons/assets.md#additional-fields), it is possible to use fields typically
+As [described in the Item spec](https://github.com/radiantearth/stac-spec/blob/master/commons/assets.md#additional-fields), it is possible to use fields typically
 found in Item properties at the asset level. This mechanism of overriding or providing Item Properties only in the Assets 
 makes discovery more difficult and should generally be avoided. However, there are some core and extension fields for which 
 providing them at the Asset level can prove to be very useful for using the data.
 
 - `datetime`: Provide individual timestamp on an Item, in case the Item has a `start_datetime` and `end_datetime`,
   but an Asset is for one specific time.
-- `gsd` ([Common Metadata](commons/common-metadata.md#instrument)): Specify some assets that represent instruments 
+- `gsd` ([Common Metadata](https://github.com/radiantearth/stac-spec/blob/master/commons/common-metadata.md#instrument)): Specify some assets that represent instruments 
   with different spatial resolution than the overall best resolution. Note this should not be used for different 
   spatial resolutions due to specific processing of assets - look into the [raster 
   extension](https://github.com/stac-extensions/raster) for that use case.
@@ -104,7 +104,7 @@ it. It is relatively easy to [register](https://www.iana.org/form/media-types) a
 
 ## Asset Roles
 
-[Asset roles](commons/assets.md#roles) are used to describe what each asset is used for. They are particular useful 
+[Asset roles](https://github.com/radiantearth/stac-spec/blob/master/commons/assets.md#roles) are used to describe what each asset is used for. They are particular useful 
 when several assets have the same media type, such as when an Item has a multispectral analytic asset, a 3-band full resolution 
 visual asset, a down-sampled preview asset, and a cloud mask asset, all stored as Cloud Optimized GeoTIFF (COG) images. It is 
 recommended to use at least one role for every asset available, and using multiple roles often makes sense. For example you'd use

--- a/best-practices-catalog-and-collection.md
+++ b/best-practices-catalog-and-collection.md
@@ -20,7 +20,7 @@
 
 
 *Note: This section uses the term 'Catalog' (with an uppercase C) to refer to the JSON entity specified in the 
-[Catalog spec](catalog-spec/catalog-spec.md), and 'catalog' (with a lowercase c) to refer to any full STAC implementation, 
+[Catalog spec](https://github.com/radiantearth/stac-spec/blob/master/catalog-spec/catalog-spec.md), and 'catalog' (with a lowercase c) to refer to any full STAC implementation, 
 which can be any mix of Catalogs, Collections, and Items.*
 
 ## Static and Dynamic Catalogs
@@ -133,7 +133,7 @@ STAC version. Otherwise some behaviour of functionality may be unpredictable (e.
 
 ## Using Summaries in Collections
 
-One of the strongest recommendations for STAC is to always provide [summaries](collection-spec/collection-spec.md#summaries) in
+One of the strongest recommendations for STAC is to always provide [summaries](https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#summaries) in
 your Collections. The core team decided to not require them, in case there are future situations where providing a summary
 is too difficult. The idea behind them is not to exhaustively summarize every single field in the Collection, but to provide
 a bit of a 'curated' view. 
@@ -148,9 +148,9 @@ while a value of 15 to 40 would tell them that it's oblique imagery, or 0 to 60 
 a Collection with lots of different look angles. 
 
 - Fields that have only one or a handful of values are also great to summarize. Collections with a single satellite may
-use a single [`gsd`](commons/common-metadata.md#instrument) field in the summary, and it's quite useful for users to know
+use a single [`gsd`](https://github.com/radiantearth/stac-spec/blob/master/commons/common-metadata.md#instrument) field in the summary, and it's quite useful for users to know
 that all data is going to be the same resolution. Similarly it's useful to know the names of all the 
-[`platform` values](commons/common-metadata.md#instrument) that are used in the Collection. 
+[`platform` values](https://github.com/radiantearth/stac-spec/blob/master/commons/common-metadata.md#instrument) that are used in the Collection. 
 
 - It is less useful to summarize fields that have numerous different discrete values that can't easily be represented
 in a range. These will mostly be string values, when there aren't just a handful of options. For example if you had a 
@@ -158,7 +158,7 @@ in a range. These will mostly be string values, when there aren't just a handful
 understand more intuitively where a shot was taken. If your Collection has millions of Items, or even hundreds, you don't want
 to include all the different location string values in a summary. 
 
-- Fields that consist of arrays are more of a judgement call. For example [`instruments`](commons/common-metadata.md#instrument)
+- Fields that consist of arrays are more of a judgement call. For example [`instruments`](https://github.com/radiantearth/stac-spec/blob/master/commons/common-metadata.md#instrument)
 is straightforward and recommended, as the elements of the array are a discrete set of options. On the other hand 
 [`proj:transform`](https://github.com/stac-extensions/projection/blob/main/README.md#projtransform)
 makes no sense to summarize, as the union of all the values

--- a/best-practices-item.md
+++ b/best-practices-item.md
@@ -32,8 +32,8 @@ instead of thinking through all the ways providers might have chosen to name it.
 In general STAC aims to be oriented around **search**, centered on the core fields that users will want to search on to find 
 imagery. The core is space and time, but there are often other metadata fields that are useful. While the specification is 
 flexible enough that providers can fill it with tens or even hundreds of fields of metadata, that is not recommended. If 
-providers have lots of metadata then that can be linked to in the [Asset Object](commons/assets.md#asset-object) 
-(recommended) or in a [Link Object](commons/links.md#link-object). There is a lot of metadata that is only of relevance 
+providers have lots of metadata then that can be linked to in the [Asset Object](https://github.com/radiantearth/stac-spec/blob/master/commons/assets.md#asset-object) 
+(recommended) or in a [Link Object](https://github.com/radiantearth/stac-spec/blob/master/commons/links.md#link-object). There is a lot of metadata that is only of relevance 
 to loading and processing data, and while STAC does not prohibit providers from putting those type of fields in their items, 
 it is not recommended. For very large catalogs (hundreds of millions of records),
 every additional field that is indexed will cost substantial money, so data providers are advised to just put the fields to be searched in STAC and
@@ -46,7 +46,7 @@ STAC. And it can also be one of the most confusing, especially for data that cov
 is straightforward - it is the capture or acquisition time. But often data is processed from a range of captures - drones usually
 gather a set of images over an hour and put them into a single image, mosaics combine data from several months, and data cubes
 represent slices of data over a range of time. For all these cases the recommended path is to use `start_datetime` and 
-`end_datetime` fields from [common metadata](commons/common-metadata.md#date-and-time-range). The specification does allow one to set the 
+`end_datetime` fields from [common metadata](https://github.com/radiantearth/stac-spec/blob/master/commons/common-metadata.md#date-and-time-range). The specification does allow one to set the 
 `datetime` field to `null`, but it is strongly recommended to populate the single `datetime` field, as that is what many clients 
 will search on. If it is at all possible to pick a nominal or representative datetime then that should be used. But sometimes that 
 is not possible, like a data cube that covers a time range from 1900 to 2000. Setting the datetime as 1950 would lead to it not
@@ -95,7 +95,7 @@ not spatial. This use case is not currently supported by STAC, as we are focused
 in nature. The [OGC API - Records](https://github.com/opengeospatial/ogcapi-records) is an emerging standard that likely
 will be able to handle a wider range of data than STAC. It builds on [OGC API - 
 Features](https://github.com/opengeospatial/ogcapi-features) just like [STAC API](https://github.com/radiantearth/stac-api-spec/)
-does. Using [Collection Assets](collection-spec/collection-spec.md#assets) may also provide an option for some 
+does. Using [Collection Assets](https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#assets) may also provide an option for some 
 use cases.
 
 ## Representing Vector Layers in STAC

--- a/best-practices-web.md
+++ b/best-practices-web.md
@@ -15,7 +15,7 @@ STAC strives to make geospatial information more accessible, by putting it on th
 different tools will be able to load and display public-facing STAC data. But the web runs on a [Same origin 
 policy](https://en.wikipedia.org/wiki/Same-origin_policy), preventing web pages from loading information from other web locations
 to prevent malicious scripts from accessing sensitive data. This means that by default a web page would only be able to load STAC
-[Item](item-spec/item-spec.md) objects from the same server the page is on.
+[Item](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md) objects from the same server the page is on.
 [Cross-origin resource sharing](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing),
 also known as 'CORS' is a protocol to enable safe communication across origins. But most web services turn it off by default. This
 is generally a good thing, but unfortunately if CORS is not enabled then any browser-based STAC tool will not work. 
@@ -25,8 +25,8 @@ So to enable all the great web tools (like [stacindex.org](http://stacindex.org)
 [Google Cloud Storage](https://cloud.google.com/storage/docs/cross-origin), or [Apache Server](https://enable-cors.org/server_apache.html). 
 Many more are listed on [enable-cors.org](https://enable-cors.org/server.html). We recommend enabling CORS for all requests ('\*'),
 so that diverse online tools can access your data. If you aren't sure if your server has CORS enabled you can use 
-[test-cors.org](https://www.test-cors.org/). Enter the URL of your STAC root [Catalog](catalog-spec/catalog-spec.md) or
-[Collection](collection-spec/collection-spec.md) JSON and make sure it gets a response.
+[test-cors.org](https://www.test-cors.org/). Enter the URL of your STAC root [Catalog](https://github.com/radiantearth/stac-spec/blob/master/catalog-spec/catalog-spec.md) or
+[Collection](https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md) JSON and make sure it gets a response.
 
 ## STAC on the Web
 

--- a/implementation-guide.md
+++ b/implementation-guide.md
@@ -22,13 +22,13 @@ else
   => Invalid (JSON)
 ```
 
-When crawling a STAC implementation, one can also make use of the [relation type](catalog-spec/catalog-spec.md#relation-types
+When crawling a STAC implementation, one can also make use of the [relation type](https://github.com/radiantearth/stac-spec/blob/master/catalog-spec/catalog-spec.md#relation-types
 ) (`rel` field) when following a link. If it is an `item` rel type then the file must be a STAC Item. If it is `child`, `parent` or
 `root` then it must be a Catalog or a Collection, though the final determination between the two requires looking at the `type` field
 in the Catalog or Collection JSON that it is linked to. Note that there is also a `type` field in STAC Link and Asset objects, but that
 is for the Media Type, but there are not specific media types for Catalog and Collection.
-See the sections on [STAC media types](commons/links.md#stac-media-types),
-and [Asset media types](commons/assets.md#media-types) for more information.
+See the sections on [STAC media types](https://github.com/radiantearth/stac-spec/blob/master/commons/links.md#stac-media-types),
+and [Asset media types](https://github.com/radiantearth/stac-spec/blob/master/commons/assets.md#media-types) for more information.
 
 In versions of STAC prior to 1.0 the process was a bit more complicated, as there was no `type` field for catalogs and collections.
 See [this issue comment](https://github.com/radiantearth/stac-spec/issues/889#issuecomment-684529444) for a heuristic that works


### PR DESCRIPTION
I noticed that there were links to the spec that assumed these docs were sitting in the same repo as the spec docs. 