### PR TITLE
Update zarr media type from application/vdn+zarr to application/vdn.zarr

### DIFF
--- a/best-practices-zarr.md
+++ b/best-practices-zarr.md
@@ -134,7 +134,7 @@ The most straightforward case is when each data variable corresponds to a unique
   "reflectance": {
     // href pointing to a group within a Zarr store
     "href": "s3://bucket/path/data.zarr/measurements/reflectance/r10m",
-    "type": "application/vnd+zarr; version=3",
+    "type": "application/vnd.zarr; version=3",
     "bands": [
       // band object for the `b02` variable within the `reflectance/r10m` Zarr group
       {"name": "b02", "eo:common_name": "blue"},
@@ -153,7 +153,7 @@ In some cases, a single data variable may contain multiple bands along a specifi
 "assets": {
   "reflectance": {
     "href": "s3://bucket/path/data.zarr/measurements",
-    "type": "application/vnd+zarr; version=3",
+    "type": "application/vnd.zarr; version=3",
     "bands": [
     {"name": "reflectance[band=blue]", "eo:common_name": "blue"},
     {"name": "reflectance[band=green]", "eo:common_name": "green"},
@@ -210,7 +210,7 @@ The key point is that the resolution group do not appear directly in the metadat
 "assets": {
     "reflectance": {
       "href": "s3://bucket/path/data.zarr/measurements/reflectance",
-      "type": "application/vnd+zarr; version=3; profile=multiscales",
+      "type": "application/vnd.zarr; version=3; profile=multiscales",
       "title": "Surface Reflectance",
       "gsd": 10,
       "bands": [
@@ -299,7 +299,7 @@ The Zarr store SHOULD be referenced with a link using the `"store"` relationship
   {
     "rel": "store",
     "href": "s3://bucket/path/data.zarr",
-    "type": "application/vnd+zarr; version=3",
+    "type": "application/vnd.zarr; version=3",
     "title": "Zarr Store"
   }
 ]

--- a/examples/CMIP6_ScenarioMIP_NCAR_CESM2.json
+++ b/examples/CMIP6_ScenarioMIP_NCAR_CESM2.json
@@ -33,7 +33,7 @@
   "assets": {
     "rlus": {
       "href": "https://storage.example.com/zarr-refs/CMIP6_CESM2_rlus.json",
-      "type": "application/vnd+zarr; version=2",
+      "type": "application/vnd.zarr; version=2",
       "title": "Surface Upwelling Longwave Radiation",
       "roles": ["data"],
       "cube:variables": {

--- a/examples/ICON_d3hp003_cf.json
+++ b/examples/ICON_d3hp003_cf.json
@@ -10,14 +10,14 @@
     {
       "rel": "store",
       "href": "s3://bucket/ICON_d3hp003.zarr",
-      "type": "application/vnd+zarr; version=2",
+      "type": "application/vnd.zarr; version=2",
       "title": "ICON Model Output Zarr Store"
     }
   ],
   "assets": {
     "P1D_mean_z5_atm": {
       "href": "s3://bucket/ICON_d3hp003.zarr/P1D_mean_z5_atm",
-      "type": "application/vnd+zarr; version=2",
+      "type": "application/vnd.zarr; version=2",
       "cube:dimensions": {
         "time": {
           "type": "temporal",

--- a/examples/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.json
+++ b/examples/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.json
@@ -149,7 +149,7 @@
     {
       "rel": "store",
       "href": "s3://esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.zarr",
-      "type": "application/vnd+zarr; version=2",
+      "type": "application/vnd.zarr; version=2",
       "title": "Sentinel-2 L2A Zarr Store"
     },
     {
@@ -166,7 +166,7 @@
   "assets": {
     "SR_10m": {
       "href": "s3://esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.zarr/measurements/reflectance/r10m",
-      "type": "application/vnd+zarr; version=2",
+      "type": "application/vnd.zarr; version=2",
       "title": "Surface Reflectance - 10m",
       "gsd": 10,
       "bands": [
@@ -206,7 +206,7 @@
     },
     "SR_20m": {
       "href": "s3://esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.zarr/measurements/reflectance/r20m",
-      "type": "application/vnd+zarr; version=2",
+      "type": "application/vnd.zarr; version=2",
       "title": "Surface Reflectance - 20m",
       "gsd": 20,
       "bands": [
@@ -281,7 +281,7 @@
     },
     "SR_60m": {
       "href": "s3://esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.zarr/measurements/reflectance/r60m",
-      "type": "application/vnd+zarr; version=2",
+      "type": "application/vnd.zarr; version=2",
       "title": "Surface Reflectance - 60m",
       "gsd": 60,
       "bands": [

--- a/examples/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613_single_asset.json
+++ b/examples/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613_single_asset.json
@@ -154,14 +154,14 @@
     {
       "rel": "store",
       "href": "s3://esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.zarr",
-      "type": "application/vnd+zarr; version=3",
+      "type": "application/vnd.zarr; version=3",
       "title": "Zarr Store"
     }
   ],
   "assets": {
     "reflectance": {
       "href": "s3://esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2A_MSIL2A_20251008T100041_N0511_R122_T32TQM_20251008T122613.zarr/measurements/reflectance",
-      "type": "application/vnd+zarr; version=3; profile=multiscales",
+      "type": "application/vnd.zarr; version=3; profile=multiscales",
       "title": "Surface Reflectance",
       "gsd": 10,
       "proj:code": "EPSG:32632",


### PR DESCRIPTION
There isn't a super authoritative source for this but on pystac we had convinced ourselves that it should be a "."

https://github.com/stac-utils/pystac/issues/1546